### PR TITLE
Enable playground simple mode

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -28,7 +28,9 @@
   },
   "api": {
     "baseUrl": "https://app.vessel.dev",
-    "hidePlayground": true,
+    "playground": {
+      "mode": "simple"
+    },
     "auth": {
       "method": "key",
       "name": "x-vessel-api-token"


### PR DESCRIPTION
# Summary

Enable the simple playground mode, which is a normal API playground but without the user interactive components